### PR TITLE
Fix build failure on PlatformIO

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,33 @@
+name: PlatformIO Examples CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example: [examples/ST7789_lib_HelloWorld]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO examples (release mode)
+        run: pio ci --lib="." -O "lib_deps=adafruit/Adafruit GFX Library@^1.12.0" --board=nanoatmega328new --board=uno
+        env:
+          PLATFORMIO_CI_SRC: ${{ matrix.example }}
+      - name: Build PlatformIO examples (debug mode)
+        run: pio ci --lib="." -O "build_type=debug" -O "lib_deps=adafruit/Adafruit GFX Library@^1.12.0" --board=nanoatmega328new --board=uno
+        env:
+          PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/ST7789_AVR.cpp
+++ b/ST7789_AVR.cpp
@@ -193,7 +193,7 @@ inline void ST7789_AVR::copyMulti(uint8_t *img, uint16_t num)
 #ifdef COMPATIBILITY_MODE
   while(num--) { SPI.transfer(*(img+1)); SPI.transfer(*(img+0)); img+=2; }
 #else
-  uint8_t lo,hi;
+  uint8_t lo = 0, hi = 0;
   asm volatile
   (
   "2:\n"

--- a/ST7789_AVR.cpp
+++ b/ST7789_AVR.cpp
@@ -160,7 +160,7 @@ inline void ST7789_AVR::writeMulti(uint16_t color, uint16_t num)
 #else
   asm volatile
   (
-  "next:\n"
+  "1:\n"
     "out %[spdr],%[hi]\n"
     "rjmp .+0\n"  // wait 8*2+1 = 17 cycles
     "rjmp .+0\n"
@@ -180,7 +180,7 @@ inline void ST7789_AVR::writeMulti(uint16_t color, uint16_t num)
     "rjmp .+0\n"
     "nop\n"
     "sbiw %[num],1\n"
-    "brne next\n"
+    "brne 1b\n"
     : [num] "+w" (num)
     : [spdr] "I" (_SFR_IO_ADDR(SPDR)), [lo] "r" ((uint8_t)color), [hi] "r" ((uint8_t)(color>>8))
   );
@@ -196,7 +196,7 @@ inline void ST7789_AVR::copyMulti(uint8_t *img, uint16_t num)
   uint8_t lo,hi;
   asm volatile
   (
-  "nextCopy:\n"
+  "2:\n"
     "ld  %[hi],%a[img]+\n"
     "ld  %[lo],%a[img]+\n"
     "out %[spdr],%[lo]\n"
@@ -216,7 +216,7 @@ inline void ST7789_AVR::copyMulti(uint8_t *img, uint16_t num)
     "rjmp .+0\n"
     "nop\n"
     "sbiw %[num],1\n"
-    "brne nextCopy\n"
+    "brne 2b\n"
     : [num] "+w" (num)
     : [spdr] "I" (_SFR_IO_ADDR(SPDR)), [img] "e" (img), [lo] "r" (lo), [hi] "r" (hi)
   );


### PR DESCRIPTION
Fixes #5 by using local numeric labels in the assembly instead of named ones (`next:`, ..). 

Also fixes a warning for using `lo` and `hi` variables uninitialized (even though it makes no difference to the code here).

Adds a simple [Github CI](https://docs.platformio.org/en/latest/integration/ci/github-actions.html) file that test-compiles the hello world example for an Arduino Nano and Uno, giving the commits a green checkmark.

The build failure occurs only for debug-optimized builds and is not hittable in the Arduino IDE.